### PR TITLE
feat: migrated from rinkeby to generic testnet config

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -44,10 +44,10 @@ module.exports = {
     // hardhat: {
     //   allowUnlimitedContractSize: true,
     // },
-    rinkeby: {
-      url: process.env.RINKEBY_RPC_URL || '',
-      accounts: process.env.RINKEBY_ADDRESS_PRIVATE_KEY
-        ? [process.env.RINKEBY_ADDRESS_PRIVATE_KEY]
+    testnet: {
+      url: process.env.TESTNET_RPC_URL || '',
+      accounts: process.env.TESTNET_ADDRESS_PRIVATE_KEY
+        ? [process.env.TESTNET_ADDRESS_PRIVATE_KEY]
         : [],
       gasPrice: 2000000000,
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "local-deploy": "hardhat run --network localhost scripts/deploys/local.ts",
     "local-gen-invite-codes": "hardhat run --network localhost scripts/generate-invite-codes.ts",
     "hardhat:local": "hardhat --network localhost",
-    "hardhat:testnet": "hardhat --network rinkeby",
+    "hardhat:testnet": "hardhat --network testnet",
     "hardhat:mainnet": "hardhat --network mainnet"
   },
   "engines": {

--- a/scripts/deploys/contract-addresses.ts
+++ b/scripts/deploys/contract-addresses.ts
@@ -12,7 +12,7 @@ export const DEPLOYED_CONTRACTS: {[key: string]: DeployedContracts} = {
     USDC: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
     DAO_MULTISIG: '0x7a77daeA5cA35a83BF529B9d72740fB965cCC5E6',
   },
-  rinkeby: {
+  testnet: {
     PRESALE: '',
     USDC: '0xD92E713d051C37EbB2561803a3b5FBAbc4962431',
     DAO_MULTISIG: '',

--- a/scripts/deploys/helpers.ts
+++ b/scripts/deploys/helpers.ts
@@ -57,7 +57,7 @@ export async function deployAndMine<T extends BaseContract, D extends (...args: 
 
 const expectedEnvvars: {[key: string]: string[]} = {
   mainnet: ['MAINNET_ADDRESS_PRIVATE_KEY', 'MAINNET_RPC_URL', 'MAINNET_GAS_IN_GWEI'],
-  rinkeby: ['RINKEBY_ADDRESS_PRIVATE_KEY', 'RINKEBY_RPC_URL'],
+  testnet: ['TESTNET_ADDRESS_PRIVATE_KEY', 'TESTNET_RPC_URL'],
   localhost: [],
 }
 


### PR DESCRIPTION
reason: rinkeby deprecated
added testnet as a generic hardhat config env vars can be used to deploy to any test network