### PR TITLE
fix: updates to Presale contract to allow for 0 cliffDuration and 0 vestingDuration

### DIFF
--- a/contracts/Presale.sol
+++ b/contracts/Presale.sol
@@ -127,11 +127,18 @@ contract Presale is Ownable {
         }
 
         uint256 currentVestingDuration = timestamp - vestingStartTimestamp;
-        if (currentVestingDuration > vestingDuration) {
-            currentVestingDuration = vestingDuration;
+        // minimum vestingDuration to 1 sec
+        uint256 _vestingDuration = 1;
+
+        if (vestingDuration > 0) {
+            _vestingDuration = vestingDuration;
         }
 
-        share = ((allocation[account] * currentVestingDuration) / vestingDuration) - claimed[account];
+        if (currentVestingDuration > _vestingDuration) {
+            currentVestingDuration = _vestingDuration;
+        }
+
+        share = ((allocation[account] * currentVestingDuration) / _vestingDuration) - claimed[account];
         amount = share * ventureToken.balanceOf(address(this)) / (totalAllocated - totalClaimed);
     }
 


### PR DESCRIPTION
Updates presale contract so that it can accept `vestingDuration = 0`

blocking #34 

